### PR TITLE
add justify-center for ruby frields items

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -219,7 +219,7 @@
           Ruby Friends
         </h3>
         <div class="flex justify-center">
-          <div class="mt-4 flex w-full md:w-1/3 md:flex-row flex-col items-center">
+          <div class="mt-4 flex w-full md:w-1/3 md:flex-row flex-col items-center justify-center">
             <%= image_tag "mohit.jpg", class: "rounded-xl border-4 border-indigo-400 h-24 w-24" %>
             <div class="pt-4 px-4 flex flex-col items-start justify-end max-sm:items-center">
                 <h3 class="text-xl font-bold text-indigo-800">


### PR DESCRIPTION
| before | after | 
| --- | --- |
| <img width="1745" alt="Screenshot 2024-04-24 at 12 48 08 AM" src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/40dfd4f5-8319-47e1-ae7d-f16325d650f8"> | <img width="1745" alt="Screenshot 2024-04-24 at 12 55 20 AM" src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/72b7a283-35fd-47b9-bbc4-9ce4d10d997d"> | 


The content inside each item for Ruby Friends is not center aligned. Looks abit weird. This PR adds a `justify-center` class to the items. Note: The header margin for my local is abit weird :p 