### PR TITLE
fix sponsor section

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -197,28 +197,26 @@
   <%= render "singapore" %>
 </div>
 
+<!-- Sponsors section -->
 <div id="sponsors" class="pb-8 relative bg-indigo-100 text-center">
   <div class="container mx-auto pt-20 mb-24 px-8 lg:px-0">
-    <h1 class="text-xl lg:text-5xl font-bold text-indigo-800">Our Sponsors</h1>
+    <h1 class="text-5xl font-bold text-indigo-800">Sponsors</h1>
 
-    <div class="max-w-2xl pt-4 mx-auto text-indigo-900">
+    <div class="max-w-2xl pt-4 mx-auto text-indigo-950">
       <p>Our sponsorship packages are a great opportunity to engage with some of the brightest minds in the ruby community through physical booths and digital media surfaces. Find out more in our Sponsorship Prospectus below!</p>
     </div>
 
     <div class="py-8 flex md:flex-row md:justify-center md:items-center flex-col">
       <a target="_blank" href="<%= current_conference.sponsorship_prospectus.presence || "mailto:organisers@reddotrubyconf.com" %>">
         <button
-          class="button mb-8 px-8 h-12 bg-indigo-600 rounded-lg cursor-pointer select-none active:translate-y-2 active:[box-shadow:0_0px_0_0_#3730a3,0_0px_0_0_#1b70f841] active:border-b-[0px] transition-all duration-150 [box-shadow:0_10px_0_0_#3730a3,0_15px_0_0_#1b70f841]"
+          class="button mb-8 px-8 h-12 bg-indigo-600 rounded-lg cursor-pointer select-none active:translate-y-2 active:[box-shadow:0_0px_0_0_#3730a3,0_0px_0_0_#1b70f841] active:border-b-[0px] transition-all duration-150 animate-bounce [box-shadow:0_10px_0_0_#3730a3,0_15px_0_0_#1b70f841]"
         >
           <span class="flex justify-center items-center h-full text-white font-bold text-lg"> <i class="fa fa-heart text-white pr-2" aria-hidden="true"></i>Become A Sponsor</span>
         </button>
       </a>
     </div>
 
-    <div class="relative mt-2 mx-auto w-7xl p-8 rounded-lg bg-slate-50 [box-shadow:0_40px_0_0_#a5b4fc,0_15px_0_0_#a5b4fc] border-4 border-indigo-800">
-
-      <!-- Partner Sponsors -->
-      <h3 class="text-4xl font-bold m-4">Our Partners</h3>
+    <div class="mt-2 mx-auto w-7xl p-8 rounded-lg bg-slate-50 [box-shadow:0_40px_0_0_#a5b4fc,0_15px_0_0_#a5b4fc] border-4 border-indigo-800">
       <div class="flex flex-wrap justify-around">
         <div class="flex content-center items-center m-4 mt-0 lg:mx-16 lg:mt-8 h-40" style="width: 300px; max-width: 300px;">
           <a href="https://www.coingecko.com/"><%= image_tag "coin_gecko.png", style: "width: 20rem;" %></a>
@@ -236,19 +234,22 @@
 
       <hr />
 
-      <!-- Ruby Friends Sponsors -->
-      <h3 class="text-3xl font-bold m-4">Ruby Friends</h3>
-      <div class="flex flex-wrap justify-around">
-        <div class="flex flex-col items-center m-8 lg:mx-16 lg:mt-8" style="width: 300px; max-width: 300px;">
-          <%= image_tag "mohit.jpg", class: "rounded-full border-4 border-indigo-400 h-32 w-32 mb-4" %>
-          <h3 class="text-xl font-bold text-indigo-800 text-start">Mohit Sindhwani</h3>
-          <p class="text-xl text-neutral-800 text-center">CTO, Quantum Inventions</p>
-        </div>
+      <h3 class="text-3xl font-bold mt-8 m-4">Ruby Friends</h3>
 
-        <div class="flex flex-col items-center m-8 lg:mx-16 lg:mt-8" style="width: 300px; max-width: 300px;">
-          <%= image_tag "https://github.com/TayKangSheng.png", class: "rounded-full border-4 border-indigo-400 h-32 w-32 mb-4" %>
-          <h3 class="text-xl font-bold text-indigo-800 text-start">Kang Sheng</h3>
-          <p class="text-xl text-neutral-800 text-center">Software Engineer</p>
+      <!-- Ruby Friends Sponsors -->
+      <div class="flex flex-wrap justify-around">
+        <div class="flex justify-center items-center flex-wrap">
+          <div class="flex flex-col items-center m-8 lg:mx-16 lg:mt-8" style="">
+            <%= image_tag "mohit.jpg", class: "rounded-full border-4 border-indigo-400 h-24 w-24 mb-4" %>
+            <h3 class="text-xl font-bold text-indigo-800 text-start">Mohit Sindhwani</h3>
+            <p class="text-xl text-neutral-800 text-center">CTO, Quantum Inventions</p>
+          </div>
+
+          <div class="flex flex-col items-center m-8 lg:mx-16 lg:mt-8" style="">
+            <%= image_tag "https://github.com/TayKangSheng.png", class: "rounded-full border-4 border-indigo-400 h-24 w-24 mb-4" %>
+            <h3 class="text-xl font-bold text-indigo-800 text-start">Kang Sheng</h3>
+            <p class="text-xl text-neutral-800 text-center">Software Engineer</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION


1. Make ruby friends image size same as speakers
2. Remove title for company sponsors section
    <img width="342" alt="Screenshot 2024-06-15 at 12 05 26 AM" src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/200cbad1-a15f-4a79-976d-a0161158acf7">
3. Make sponsor section title bigger
    <img width="342" alt="Screenshot 2024-06-14 at 11 59 41 PM" src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/b87c28b7-362b-45ba-9d66-aab3aa2ef1c8">
4. Make sponsor button bounce
    <video src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/57416dbe-7106-4474-a219-54d569414ec4"></video>

