### PR TITLE
prevent navbar a tags from refreshing page

### DIFF
--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,8 +1,8 @@
 <div class="fixed top-0 w-screen h-16 z-50 bg-teal-100 border-b-4 border-b-teal-800 flex justify-end items-center text-xs md:text-sm">
-  <%= link_to "Tickets", "#tickets", class: "mr-4 text-teal-800 font-bold rounded-lg" %>
-  <%= link_to "Speakers", "#speakers", class: "mr-4 text-teal-800 font-bold rounded-lg" %>
-  <%= link_to "Venue", "#venue", class: "mr-4 text-teal-800 font-bold rounded-lg" %>
-  <%= link_to "Sponsors", "#sponsors", class: "mr-4 text-teal-800 font-bold rounded-lg" %>
+  <%= link_to "Tickets", "#tickets", class: "mr-4 text-teal-800 font-bold rounded-lg", data: { turbo: "false" } %>
+  <%= link_to "Speakers", "#speakers", class: "mr-4 text-teal-800 font-bold rounded-lg", data: { turbo: "false" } %>
+  <%= link_to "Venue", "#venue", class: "mr-4 text-teal-800 font-bold rounded-lg", data: { turbo: "false" } %>
+  <%= link_to "Sponsors", "#sponsors", class: "mr-4 text-teal-800 font-bold rounded-lg", data: { turbo: "false" } %>
 </div>
 
 <div class="container mx-auto mb-32 px-8 lg:px-0">
@@ -17,8 +17,7 @@
       </div>
       <%= image_tag "wavy.png", class: "max-sm:hidden w-48 mb-12" %>
     </div>
-    <div id="tickets"></div>
-    <div class="w-full lg:w-4/12">
+    <div id="tickets" class="w-full lg:w-4/12">
       <tito-widget event="cu/rdrc24"></tito-widget>
     </div>
     <div>


### PR DESCRIPTION
The anchor tags are causing page refresh. Not really a big problem but the Tito widget reloads again which means that when you click on the tickets anchor, the tito widget disappears when you need it. 

| Before | After |
| --- | --- |
| <video src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/73aa062d-23a7-4de1-816b-d886a6c979cd"></video> | <video src="https://github.com/reddotrubyconf/little_red_dot/assets/10722197/539d78c7-33c4-4979-a692-216cf2445c08"></video> |

# How does this PR work 

1. use `data-turbo=false` to prevent page refresh. [Stackoverflow](https://stackoverflow.com/questions/70921317/how-can-i-disable-hotwire-turbo-the-turbolinks-replacement-for-all-forms-in) [Stackoverflow](https://github.com/hotwired/turbo/issues/119#issuecomment-765682306)